### PR TITLE
Fixes broken xrGamepadComponent.test.js

### DIFF
--- a/src/xrGamepadComponent.js
+++ b/src/xrGamepadComponent.js
@@ -209,6 +209,10 @@ class XRGamepadComponent {
     // component's current state (press/touch).
     this.visualResponses.forEach((visualResponse) => {
       let visualResponseState = visualResponse[data.state];
+      if (!visualResponseState && (data.state == Constants.ComponentState.PRESSED)) {
+        visualResponseState = visualResponse[Constants.ComponentState.TOUCHED];
+      }
+
       if (visualResponseState) {
         let weightedVisualResponse = {};
         


### PR DESCRIPTION
Well, this is somewhat embarrassing.  It turns out one of the fancy new test files I added was only passing on accident.  It uses a TestHelper to build data objects to validate against, but wasn't passing any actual overriden values into the function due to a last-minute variable rename.  The result was that all the tests were all validating the exact same default values.

This is now fixed, and while I was at it I moved the data object generation into a common location.