### PR TITLE
Adds static function to XRGamepad for getting a mapping object

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,9 +1,19 @@
-module.exports = {
-  MappingType: {
-    WEBXR: "WebXR",
-    WEBVR: "WebVR",
-    MOCK: "mock"
-  },
+const { join } = require('path');
+
+const MappingType = Object.freeze({
+  WEBXR: "WebXR",
+  WEBVR: "WebVR",
+  MOCK: "mock"
+});
+
+const Constants = {
+  MappingType: MappingType,
+
+  MappingFolders: Object.freeze({
+    [MappingType.WEBXR]: join(__dirname, "../mappings/WebXR/"),
+    [MappingType.WEBVR]: join(__dirname, "../mappings/WebVR/"),
+    [MappingType.MOCK]: join(__dirname, "../tests/mockMappings/")
+  }), 
 
   Handedness: Object.freeze({
     NONE: "none",
@@ -28,4 +38,6 @@ module.exports = {
   TouchThreshold: 0.2,
   
   PressThreshold: 0.95
-}
+};
+
+module.exports = Constants;

--- a/src/xrGamepad.js
+++ b/src/xrGamepad.js
@@ -71,6 +71,21 @@ class XRGamepad {
   get root() {
     return this.hand.root;
   }
+
+  /**
+   * @description Gets the mapping description for the supplied gamepad id
+   * @param {String} gamepadId The id of the Gamepad to find the mapping for
+   * @param {string} [mappingType="WebXR"] Indicates the folder from which
+   * mapping should be enumerated
+   * @returns {Object} The mapping described in the mapping.json file
+   */
+  static getMapping(gamepadId, mappingType = Constants.MappingType.WEBXR) {
+    const { join } = require('path');
+    const folder = Constants.MappingFolders[mappingType];
+    const mappingPath = join(folder, gamepadId, "mapping.json");
+    const mapping = require(mappingPath);
+    return mapping;
+  }
 };
 
 module.exports = XRGamepad;

--- a/tests/mappings.test.js
+++ b/tests/mappings.test.js
@@ -2,19 +2,9 @@ const TestHelpers = require("./testHelpers.js");
 const validator = TestHelpers.getValidator();
 const Constants = require("../src/constants.js");
 
-const createTestTable = function(mappingType) {
-  const mappingList = TestHelpers.getMappingsList(mappingType);
-  return Array.from(mappingList, (gamepadId) => [gamepadId, mappingType]);
-}
+const testTable = Array.from(TestHelpers.getMappingsList(), (entry) => [ entry.testName, entry]);
 
-const testTable = [
-  ...createTestTable(Constants.MappingType.WEBXR),
-  ...createTestTable(Constants.MappingType.WEBVR),
-  ...createTestTable(Constants.MappingType.MOCK)
-];
-
-describe.each(testTable)("validateMapping.%s", (gamepadId, mappingType) => {
-  const mapping = TestHelpers.getMappingById(gamepadId, mappingType);
+describe.each(testTable)("validateMapping.%s", (testName, {mappingType, mapping}) => {
 
   test("Mapping exists and passes schema validation", () => {
     expect(mapping).not.toBeNull();

--- a/tests/mockGamepads.test.js
+++ b/tests/mockGamepads.test.js
@@ -1,28 +1,15 @@
 const TestHelpers = require("./testHelpers.js");
-const Constants = require("../src/constants.js");
 const MockGamepad = require("./mockGamepad/mockGamepad.js");
 
-const createTestTable = function(mappingType) {
-  let testTable = [];
-
-  const mappingList = TestHelpers.getMappingsList(mappingType);
-  mappingList.forEach((gamepadId) => {
-    let mapping = TestHelpers.getMappingById(gamepadId, mappingType);
-    Object.keys(mapping.handedness).forEach((handedness) => {
-      testTable.push([gamepadId, handedness, mapping]);
-    });
+const testsTable = [];
+TestHelpers.getMappingsList().forEach((entry) => {
+  Object.keys(entry.mapping.handedness).forEach((handedness) => {
+    const testName = `${entry.testName}.${handedness}`;
+    testsTable.push([ testName, { handedness: handedness, mapping: entry.mapping }]);
   });
+});
 
-  return testTable;
-}
-
-const testsTable = [
-  ...createTestTable(Constants.MappingType.WEBXR),
-  ...createTestTable(Constants.MappingType.WEBVR),
-  ...createTestTable(Constants.MappingType.MOCK)
-];
-
-test.each(testsTable)("mockGamepad.%s.%s", (gamepadId, handedness, mapping) => {
+test.each(testsTable)("mockGamepad.%s", (testName, {handedness, mapping}) => {
   let mockGamepad = new MockGamepad(mapping, handedness);
   expect(mockGamepad).toBeDefined();
 });

--- a/tests/schemaTests/schema.test.js
+++ b/tests/schemaTests/schema.test.js
@@ -1,7 +1,8 @@
 const TestHelpers = require("../testHelpers.js");
 const validator = TestHelpers.getValidator();
-const Constants = require("../../src/constants.js");
-const validMapping = Object.freeze(TestHelpers.getMappingById("mock1", Constants.MappingType.MOCK));
+const { MappingType } = require("../../src/constants.js");
+const XRGamepad = require("../../src/xrGamepad.js");
+const validMapping = Object.freeze(XRGamepad.getMapping("mock1", MappingType.MOCK));
 
 test("Valid mapping", () => {
   let valid = false;

--- a/tests/xrGamepad.test.js
+++ b/tests/xrGamepad.test.js
@@ -5,7 +5,7 @@ const XRGamepad = require("../src/xrGamepad.js");
 
 const validGamepadId = "mock3";
 const validHandedness = Constants.Handedness.NONE;
-const validMapping = Object.freeze(TestHelpers.getMappingById(validGamepadId, Constants.MappingType.MOCK));
+const validMapping = Object.freeze(XRGamepad.getMapping(validGamepadId, Constants.MappingType.MOCK));
 const validGamepad = new MockGamepad(validMapping, validHandedness);
 
 test("Constructor - invalid gamepad", () => {
@@ -55,27 +55,15 @@ test("Constructor - mismatched ids", () => {
   }).toThrow();
 });
 
-const createTestTable = function(mappingType) {
-  const testTable = [];
-
-  const mappingList = TestHelpers.getMappingsList(mappingType);
-  mappingList.forEach((gamepadId) => {
-    let mapping = TestHelpers.getMappingById(gamepadId, mappingType);
-    Object.keys(mapping.handedness).forEach((handednessKey) => {
-      testTable.push([gamepadId, handednessKey, mapping]);
-    });
+const testsTable = [];
+TestHelpers.getMappingsList().forEach((entry) => {
+  Object.keys(entry.mapping.handedness).forEach((handedness) => {
+    const testName = `${entry.testName}.${handedness}`;
+    testsTable.push([ testName, { handedness: handedness, mapping: entry.mapping }]);
   });
+});
 
-  return testTable;
-}
-
-const testTable = [
-  ...createTestTable(Constants.MappingType.WEBXR),
-  ...createTestTable(Constants.MappingType.WEBVR),
-  ...createTestTable(Constants.MappingType.MOCK)
-];
-
-describe.each(testTable)("xrGamepad.%s.%s", (gamepadId, handedness, mapping) => {
+describe.each(testsTable)("xrGamepad.%s", (testName, {handedness, mapping}) => {
 
   test("Create an XRGamepad", () => {
     let mockGamepad = new MockGamepad(mapping, handedness);

--- a/tests/xrGamepadComponent.test.js
+++ b/tests/xrGamepadComponent.test.js
@@ -1,11 +1,12 @@
 const TestHelpers = require("./testHelpers.js");
 const MockGamepad = require("./mockGamepad/mockGamepad.js");
+const XRGamepad = require("../src/xrGamepad.js");
 const XRGamepadComponent = require("../src/xrGamepadComponent.js");
 const Constants = require("../src/constants.js");
 
 const gamepadId = "mock3";
 const handedness = Constants.Handedness.NONE;
-const mapping = Object.freeze(TestHelpers.getMappingById(gamepadId, Constants.MappingType.MOCK));
+const mapping = Object.freeze(XRGamepad.getMapping(gamepadId, Constants.MappingType.MOCK));
 const mockGamepad = new MockGamepad(mapping, handedness);
 const asButtons = true;
 


### PR DESCRIPTION
Removes the TestHelper.getMappingById(), changes TestHelper.getMappingList()
to enumerate across all mappingTypes, updates tests to use the new functions